### PR TITLE
Added transformation for reversing words

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,11 @@ Therefore text transformation handlers can be registered at the core of the exte
 
 ---
 
-Currently there are three transformations included:
+Currently there are four transformations included:
 - to uppercase
 - to lowercase 
 - to capitalcase (capitalizing the first letter of each word<sup>*</sup>)
+- reverse words
 
 <sup>*</sup> a word is always starting after a common whitespace character + at the start of the selection
 

--- a/package.json
+++ b/package.json
@@ -29,6 +29,10 @@
             {
                 "command": "capitalcase",
                 "title": "To capitalcase"
+            },
+            {
+                "command": "reversewords",
+                "title": "Reverse words"
             }
         ]
     },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,11 +1,12 @@
 import {ExtensionContext, window, commands, Selection, Range, TextEditorEdit} from "vscode";
 import Transformation from "./transformation";
-import {UppercaseTransformer, LowercaseTransformer, CapitalcaseTransformer} from "./simple-transformations";
+import {UppercaseTransformer, LowercaseTransformer, CapitalcaseTransformer, ReverseWordsTransformer} from "./simple-transformations";
 
 export const transformers = new Array<Transformation>();
 transformers.push(new UppercaseTransformer());
 transformers.push(new LowercaseTransformer());
 transformers.push(new CapitalcaseTransformer());
+transformers.push(new ReverseWordsTransformer());
 
 //This is needed to be able to inject a spy transformer during testing
 let context: ExtensionContext;

--- a/src/simple-transformations.ts
+++ b/src/simple-transformations.ts
@@ -46,3 +46,20 @@ export class CapitalcaseTransformer extends Transformation {
         cb(newString);
     }
 }
+
+export class ReverseWordsTransformer extends Transformation {
+    getCommandName(): string {
+        return "reversewords";
+    }
+
+    transform(input: string, cb: (output: string) => void): void {
+        let reverse = (str: string) => str.split(" ").reverse().join(" ");
+        
+        let outString = input.split("\n").map((line) => {
+            // Trim the string in order to maintain indentation
+            return line.replace(line.trim(), reverse(line.trim()));
+        }).join("\n");
+
+        cb(outString);
+    }
+}

--- a/test/extension.test.ts
+++ b/test/extension.test.ts
@@ -54,7 +54,7 @@ suite("integration test", () => {
 
 
 
-import {CapitalcaseTransformer} from "../src/simple-transformations";
+import {CapitalcaseTransformer, ReverseWordsTransformer} from "../src/simple-transformations";
 
 suite("unit tests", () => {
     suite("capitalcase", () => {
@@ -64,6 +64,27 @@ suite("unit tests", () => {
         test("correct handling of multiword input", (done: MochaDone) => {
             instance.transform(SAMPLE_SENTENCE, (output: string) => {
                 assert.equal(output, "Hallo\tWelt,\nIch Freue   Mich!");
+                done();
+            });
+        });
+    });
+    
+    suite("reversewords", () => {
+        let instance = new ReverseWordsTransformer();
+        const SAMPLE_CODE_USE = "foo === true";
+        const SAMPLE_MULTILINE_SENTENCE = "\t\tThis is some text\n    And some in new line!";
+
+        test("correct handling of operators", (done: MochaDone) => {
+            instance.transform(SAMPLE_CODE_USE, (output: string) => {
+                assert.equal(output, "true === foo");
+                done();
+            });
+        });
+
+        // We want to reverse only words in line, and preserve indentation across multiple lines
+        test("correct handling of multiline input", (done: MochaDone) => {
+            instance.transform(SAMPLE_MULTILINE_SENTENCE, (output: string) => {
+                assert.equal(output, "\t\ttext some is This\n    line! new in some And");
                 done();
             });
         });


### PR DESCRIPTION
I wanted a transformation to reverse the order of words (/operators), so I added functionality here. I also wrote some simple unit tests.

I made it work for each line of text separately, and ignoring the indentation.